### PR TITLE
Performance and cosmetic improvement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
     const newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
     if (foundLoader.include || foundLoader.exclude) {
-      return [...mergedLoaderConfigs, loaderConfig];
+      return mergedLoaderConfigs.concat(loaderConfig);
     }
 
     foundLoader.loaders = newLoaders.reduce((mergedLoaders, loader) => {
@@ -21,12 +21,12 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
 
       if (mergedLoaders.every(l => loaderName !== l.match(loaderNameRe)[0])) {
         // prepend because of rtl (latter objects should be able to build the chain)
-        return [...mergedLoaders, loader];
+        return mergedLoaders.concat(loader);
       }
       return mergedLoaders;
     }, foundLoader.loaders);
   } else if (!foundLoader) {
-    return [...mergedLoaderConfigs, loaderConfig];
+    return mergedLoaderConfigs.concat(loaderConfig);
   }
 
   return mergedLoaderConfigs;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,16 @@ const find = require('lodash.find');
 
 const loaderNameRe = new RegExp(/[a-z\-]/ig);
 
+function mergeLoaders(currentLoaders, newLoaders) {
+  return newLoaders.reduce((mergedLoaders, loader) => {
+    if (mergedLoaders.every(l => loader.match(loaderNameRe)[0] !== l.match(loaderNameRe)[0])) {
+      // prepend because of rtl (latter objects should be able to build the chain)
+      return mergedLoaders.concat(loader);
+    }
+    return mergedLoaders;
+  }, currentLoaders);
+}
+
 function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   const foundLoader = find(mergedLoaderConfigs, l => String(l.test) === String(loaderConfig.test));
 
@@ -16,15 +26,7 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
       return mergedLoaderConfigs.concat(loaderConfig);
     }
 
-    foundLoader.loaders = newLoaders.reduce((mergedLoaders, loader) => {
-      const loaderName = loader.match(loaderNameRe)[0];
-
-      if (mergedLoaders.every(l => loaderName !== l.match(loaderNameRe)[0])) {
-        // prepend because of rtl (latter objects should be able to build the chain)
-        return mergedLoaders.concat(loader);
-      }
-      return mergedLoaders;
-    }, foundLoader.loaders);
+    foundLoader.loaders = mergeLoaders(foundLoader.loaders, newLoaders);
   } else if (!foundLoader) {
     return mergedLoaderConfigs.concat(loaderConfig);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   const foundLoader = find(mergedLoaderConfigs, l => String(l.test) === String(loaderConfig.test));
 
   // foundLoader.loader is intentionally ignored, because a string loader value should always override
-  if (foundLoader && foundLoader.loaders) {
+  if (foundLoader.loaders) {
     const newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
     if (foundLoader.include || foundLoader.exclude) {


### PR DESCRIPTION
This PR consist of three commits:

#### `use concat instead of spread operator`:
This commit changes the uses of spread operator concatenation in favor con the `Array.prototype.concat` function, since its intention is more clear for the reader and the performance over the other options is better.

**References:**
[Combining JavaScript Arrays - David Walsh Blog](https://davidwalsh.name/combining-js-arrays)
[JSPerf - Array Concat Performance](http://jsperf.com/array-concatenation-performance/2)

#### `extract function for readability and possible reuse` and `remove the unnecessary foundLoader validation`:
This is a change that only affects the aesthetics of function, making it much easier to read and understand.

**Particular changes:**
- Remove the unnecessary validation of the `foundLoaders` object, since this must already exist for the `foundLoader.loaders` validation to pass
- Extract the `mergeLoaders` function in order to simplify the `reduceLoaders` and make the code more readable
- Remove the `loaderName` const declaration since this constant is not going to be use in more than one place. so is not necessary to cache it