### PR TITLE
Fixing error: "TypeError: Cannot read property 'loaders' of undefined"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.tern-port

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   });
 
   // foundLoader.loader is intentionally ignored, because a string loader value should always override
-  if (foundLoader.loaders) {
+  if (foundLoader && foundLoader.loaders) {
     var newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
     if (foundLoader.include || foundLoader.exclude) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   const foundLoader = find(mergedLoaderConfigs, l => String(l.test) === String(loaderConfig.test));
 
   // foundLoader.loader is intentionally ignored, because a string loader value should always override
-  if (foundLoader.loaders) {
+  if (foundLoader && foundLoader.loaders) {
     const newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
     if (foundLoader.include || foundLoader.exclude) {

--- a/test.js
+++ b/test.js
@@ -501,4 +501,31 @@ function mergeTests(merge) {
 
     assert.deepEqual(merge(a, b, result), result);
   });
+
+  it('should not error when there are no matching loaders', function () {
+    const a = {
+      loaders: [{
+        test: /\.js$/,
+        loader: 'a'
+      }]
+    };
+    const b = {
+      loaders: [{
+        test: /\.css$/,
+        loader: 'b'
+      }]
+    };
+    const result = {
+      loaders: [{
+        test: /\.css$/,
+        loader: 'b'
+      }, {
+        test: /\.js$/,
+        loader: 'a'
+      }]
+    };
+
+    assert.deepEqual(merge(a, b), result);
+  });
+
 }


### PR DESCRIPTION
Lodash's find returns undefined if it does not find a match, so we need to ensure it did not return undefined before referencing the properties of it's return value.

```
TypeError: Cannot read property 'loaders' of undefined
    at reduceLoaders ([...]/node_modules/webpack-merge/lib/index.js:32:18)
    at Array.reduce (native)
    [...]
```