### PR TITLE
Decouple the include/exclude from foundLoader.loaders

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,14 +33,14 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
       var newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
       foundLoader.loaders = mergeLoaders(foundLoader.loaders, newLoaders);
+    }
 
-      if (loaderConfig.include) {
-        foundLoader.include = loaderConfig.include;
-      }
+    if (loaderConfig.include) {
+      foundLoader.include = loaderConfig.include;
+    }
 
-      if (loaderConfig.exclude) {
-        foundLoader.exclude = loaderConfig.exclude;
-      }
+    if (loaderConfig.exclude) {
+      foundLoader.exclude = loaderConfig.exclude;
     }
 
     return mergedLoaderConfigs;

--- a/src/index.js
+++ b/src/index.js
@@ -30,14 +30,14 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
       const newLoaders = loaderConfig.loader ? [loaderConfig.loader] : loaderConfig.loaders || [];
 
       foundLoader.loaders = mergeLoaders(foundLoader.loaders, newLoaders);
+    }
 
-      if (loaderConfig.include) {
-        foundLoader.include = loaderConfig.include;
-      }
+    if (loaderConfig.include) {
+      foundLoader.include = loaderConfig.include;
+    }
 
-      if (loaderConfig.exclude) {
-        foundLoader.exclude = loaderConfig.exclude;
-      }
+    if (loaderConfig.exclude) {
+      foundLoader.exclude = loaderConfig.exclude;
     }
 
     return mergedLoaderConfigs;

--- a/test.js
+++ b/test.js
@@ -580,6 +580,60 @@ function smartMergeTests(merge, loadersKey) {
 
     assert.deepEqual(merge(common, strip), result);
   });
+
+  it('should use parent include/exclude even if only loader string is specified for ' + loadersKey, function () {
+    const common = {
+      module: {}
+    };
+    common.module[loadersKey] = [
+      {
+        test: /\.js$/,
+        include: [
+          'apps',
+          'lib',
+          'thirdparty'
+        ],
+        exclude: /node_modules/,
+        loaders: 'eslint'
+      }
+    ];
+    const eslint = {
+      module: {}
+    };
+    eslint.module[loadersKey] = [
+      {
+        test: /\.js$/,
+        loader: 'eslint',
+        query: {
+          rules: {
+            'no-debugger': 0
+          }
+        }
+      }
+    ];
+    const result = {
+      module: {}
+    };
+    result.module[loadersKey] = [
+      {
+        test: /\.js$/,
+        loader: 'eslint',
+        query: {
+          rules: {
+            'no-debugger': 0
+          }
+        },
+        include: [
+          'apps',
+          'lib',
+          'thirdparty'
+        ],
+        exclude: /node_modules/
+      }
+    ];
+
+    assert.deepEqual(merge(common, eslint), result);
+  });
 }
 
 function mergeTests(merge) {


### PR DESCRIPTION
Found another issue related to #15:

Seems like the include/exclude is not being added if you don't specify loaders

```javascript
// Common.config.js
{
    // ...
    module: {
        loaders: [
            {
                test: /\.js$/,
                loader: 'eslint-loader',
                exclude: /node_modules|thirdparty/,
            },
        ],
    },
    // ...
}
```

```javascript
// production.config.js
{
    // ...
    module: {
        loaders: [
            {
                test: /\.js$/,
                loader: 'eslint-loader',
                query: {
                    rules: {
                        'no-debugger': 0,
                    },
                },
            }
        ],
    },
    // ...
}
```

```javascript
// Actual merge.smart output
{
    // ...
    module: {
        loaders: [
            {
                test: /\.js$/,
                loader: 'eslint-loader',
                query: {
                    rules: {
                        'no-debugger': 0,
                    },
                },
            },
        ],
    },
    // ...
}
```

```javascript
// Expected merge.smart output
{
    // ...
    module: {
        loaders: [
            {
                test: /\.js$/,
                exclude: /node_modules|thirdparty/,
                loader: 'eslint-loader',
                query: {
                    rules: {
                        'no-debugger': 0,
                    },
                },
            },
        ],
    },
    // ...
}
```
