### PR TITLE
Check for `include/exclude` equality for smarter merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "lodash.find": "^3.2.1",
+    "lodash.isequal": "^4.2.0",
     "lodash.isplainobject": "^3.2.0",
     "lodash.merge": "^3.3.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const isArray = Array.isArray;
 const isPlainObject = require('lodash.isplainobject');
 const merge = require('lodash.merge');
 const find = require('lodash.find');
+const isEqual = require('lodash.isequal');
 
 const loaderNameRe = new RegExp(/[a-z\-]/ig);
 
@@ -14,6 +15,19 @@ function mergeLoaders(currentLoaders, newLoaders) {
   }, currentLoaders);
 }
 
+/**
+ * Check equality of two values using lodash's isEqual
+ * Arrays need to be sorted for equality checking
+ * but clone them first so as not to disrupt the sort order in tests
+ */
+function isSameValue(a, b) {
+  const [propA, propB] = [a, b].map(function (value) {
+    return isArray(value) ? Array.from(value).sort() : value;
+  });
+
+  return isEqual(propA, propB);
+}
+
 function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   const foundLoader = find(
     mergedLoaderConfigs,
@@ -21,7 +35,12 @@ function reduceLoaders(mergedLoaderConfigs, loaderConfig) {
   );
 
   if (foundLoader) {
-    if (foundLoader.include || foundLoader.exclude) {
+    /**
+     * When both loaders have different `include` or `exclude`
+     * properties, concat them
+     */
+    if ((foundLoader.include && !isSameValue(foundLoader.include, loaderConfig.include)) ||
+        (foundLoader.exclude && !isSameValue(foundLoader.exclude, loaderConfig.exclude))) {
       return mergedLoaderConfigs.concat([loaderConfig]);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function mergeLoaders(currentLoaders, newLoaders) {
  */
 function isSameValue(a, b) {
   const [propA, propB] = [a, b].map(function (value) {
-    return isArray(value) ? Array.from(value).sort() : value;
+    return isArray(value) ? value.slice().sort() : value;
   });
 
   return isEqual(propA, propB);

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ describe('Merge', function () {
 describe('Smart merge', function () {
   const merge = webpackMerge.smart;
 
+  smartMergeIssueTest(merge);
   smartMergeTests(merge, 'preLoaders');
   smartMergeTests(merge, 'loaders');
   smartMergeTests(merge, 'postLoaders');
@@ -654,6 +655,46 @@ function smartMergeTests(merge, loadersKey) {
     ];
 
     assert.deepEqual(merge(common, eslint), result);
+  });
+}
+
+function smartMergeIssueTest(merge) {
+  it('should merge with matching exclude and loaders', function () {
+    const a = {
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loaders: ['babel']
+          }
+        ]
+      }
+    };
+    const b = {
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loaders: ['coffee', 'foo']
+          }
+        ]
+      }
+    };
+    const result = {
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loaders: ['coffee', 'foo', 'babel']
+          }
+        ]
+      }
+    };
+
+    assert.deepEqual(merge(a, b), result);
   });
 }
 


### PR DESCRIPTION
Closes #21 

While reducing, if both loaders have the same value (regex or array) merge them smartly instead of concat'ing them.

Adds a test case as well.

Note: I did add `lodash.isequal` in an effort to shave off a lot of extra code that handles converting regex to string for comparison or handles array comparisons. Let me know if you'd prefer to keep `lodash.isequal` out.