### PR TITLE
Add basic test for object merge

### DIFF
--- a/test.js
+++ b/test.js
@@ -771,6 +771,23 @@ function mergeTests(merge) {
 
     assert.deepEqual(merge(a, b, result), result);
   });
+  
+  it('should deeply merge objects', function () {
+    const a = {
+      foo: {bar: 'a'}
+    };
+    const b = {
+      foo: {baz: 'b'}
+    };
+    const result = {
+      foo: {
+        bar: 'a',
+        baz: 'b'
+      }
+    };
+    
+    assert.deepEqual(merge(a, b), result);
+  });
 
   it('should not error when there are no matching loaders', function () {
     const a = {

--- a/test.js
+++ b/test.js
@@ -771,13 +771,13 @@ function mergeTests(merge) {
 
     assert.deepEqual(merge(a, b, result), result);
   });
-  
+
   it('should deeply merge objects', function () {
     const a = {
-      foo: {bar: 'a'}
+      foo: { bar: 'a' }
     };
     const b = {
-      foo: {baz: 'b'}
+      foo: { baz: 'b' }
     };
     const result = {
       foo: {
@@ -785,7 +785,7 @@ function mergeTests(merge) {
         baz: 'b'
       }
     };
-    
+
     assert.deepEqual(merge(a, b), result);
   });
 


### PR DESCRIPTION
While there are tests for more elaborate merge behaviors, there doesn't seem to be a basic test for the keys of nested objects together.

Addresses #24 