### PR TITLE
Fix loader merging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var merge = require('lodash.merge');
 var find = require('lodash.find');
 var isEqual = require('lodash.isequal');
 
-var loaderNameRe = new RegExp(/[a-z\-]/ig);
+var loaderNameRe = /^([^\?]+)/ig;
 
 function mergeLoaders(currentLoaders, newLoaders) {
   return newLoaders.reduce(function (mergedLoaders, loader) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const merge = require('lodash.merge');
 const find = require('lodash.find');
 const isEqual = require('lodash.isequal');
 
-const loaderNameRe = new RegExp(/[a-z\-]/ig);
+const loaderNameRe = /^([^\?]+)/ig;
 
 function mergeLoaders(currentLoaders, newLoaders) {
   return newLoaders.reduce((mergedLoaders, loader) => {

--- a/test.js
+++ b/test.js
@@ -239,6 +239,54 @@ function smartMergeTests(merge, loadersKey) {
     assert.deepEqual(merge(a, b), result);
   });
 
+  it('should compare loaders by their whole name ' + loadersKey, function () {
+    const a = {};
+    a[loadersKey] = [{
+      test: /\.js$/,
+      loaders: ['aa']
+    }];
+    const b = {};
+    b[loadersKey] = [{
+      test: /\.js$/,
+      loaders: ['ab']
+    }];
+    const result = {};
+    result[loadersKey] = [{
+      test: /\.js$/,
+      // loaders are evaluated from right to left so it makes sense to
+      // prepend here!!! this is an exception given normally we want to
+      // append instead. without this the loader order doesn't make
+      // any sense in this case
+      loaders: ['ab', 'aa']
+    }];
+
+    assert.deepEqual(merge(a, b), result);
+  });
+
+  it('should be able to merge loaders referenced by path with ' + loadersKey, function () {
+    const a = {};
+    a[loadersKey] = [{
+      test: /\.js$/,
+      loaders: ['/foo/bar-a.js?a=b']
+    }];
+    const b = {};
+    b[loadersKey] = [{
+      test: /\.js$/,
+      loaders: ['/foo/bar-b.js?c=d']
+    }];
+    const result = {};
+    result[loadersKey] = [{
+      test: /\.js$/,
+      // loaders are evaluated from right to left so it makes sense to
+      // prepend here!!! this is an exception given normally we want to
+      // append instead. without this the loader order doesn't make
+      // any sense in this case
+      loaders: ['/foo/bar-b.js?c=d', '/foo/bar-a.js?a=b']
+    }];
+
+    assert.deepEqual(merge(a, b), result);
+  });
+
   it('should prepend loader and loaders with ' + loadersKey, function () {
     const a = {};
     a[loadersKey] = [{


### PR DESCRIPTION
Loader merging was accidentially only done by comparing the first letter
of the loader name.

So

```js
webpackMerge.smart({
  loaders: [
    {
      test: /\.scss$/,
      loaders: [
        'css',
        'sass'
      ]
    }
  ]
}, {
  loaders: [
    {
      test: /\.scss$/,
      loaders: [
        'style'
      ]
    }
  ]
})
```

became

```js
{
  loaders: [
    {
      test: /\.scss$/,
      loaders: [
        'style',
        'css'
      ]
    }
  ]
}
```

because of `style` and `sass` both starting with a `s`.

EDIT: Allow fixed that merging loaders reference by path (like `ExtractTextPlugin`) was not possible.