### PR TITLE
Support merging plugins, tweak rule merging behavior

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "comma-dangle": [2, "never"],
     "no-undef": [2],
     "no-undefined": 1,
+    "no-underscore-dangle": 0,
     "no-use-before-define": 0,
     // http://eslint.org/docs/rules/prefer-const
     "prefer-const": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   "rules": {
     "func-names": 0,
     "comma-dangle": [2, "never"],
+    "consistent-return": 0,
     "no-undef": [2],
     "no-undefined": 1,
     "no-underscore-dangle": 0,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src -d lib",
     "watch": "npm-watch",
     "test": "mocha tests/test-*",
-    "test:lint": "eslint . ---cache",
+    "test:lint": "eslint . --cache",
     "preversion": "npm run test:lint && npm run build && npm test && git commit --allow-empty -am \"Update lib\""
   },
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,15 @@
     "lib"
   ],
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
+    "lodash.clonedeepwith": "^4.5.0",
     "lodash.differencewith": "^4.5.0",
+    "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.4.0",
     "lodash.isfunction": "^3.0.8",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isobject": "^3.0.2",
     "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
     "lodash.mergewith": "^4.6.0",
     "lodash.unionwith": "^4.6.0"
   },
@@ -28,12 +32,13 @@
     "babel-preset-es2015": "^6.3.13",
     "eslint": "^3.12.0",
     "eslint-config-airbnb": "^13.0.0",
-    "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.8.0",
     "git-prepush-hook": "^1.0.1",
     "mocha": "^3.2.0",
-    "npm-watch": "^0.1.6"
+    "npm-watch": "^0.1.6",
+    "webpack": "^2.2.0-rc.0"
   },
   "repository": {
     "type": "git",

--- a/src/join-arrays-smart.js
+++ b/src/join-arrays-smart.js
@@ -1,5 +1,4 @@
 const isEqual = require('lodash.isequal');
-const isFunction = require('lodash.isfunction');
 const mergeWith = require('lodash.mergewith');
 const unionWith = require('lodash.unionwith');
 const differenceWith = require('lodash.differencewith');
@@ -125,10 +124,10 @@ function uniteEntries(newEntry, entry) {
 }
 
 function unitePlugins(newPlugin, plugin) {
-  if (!(newPlugin instanceof plugin.constructor)) return false;
-
-  // functions shouldn't be merged here
-  mergeWith(plugin, newPlugin, (a, b, k) => (isFunction(a) ? a : joinArrays()(a, b, k)));
+  if (!(newPlugin instanceof plugin.constructor)) {
+    return false;
+  }
+  joinArrays()(plugin, newPlugin, 'plugins');
   return true;
 }
 

--- a/src/join-arrays-smart.js
+++ b/src/join-arrays-smart.js
@@ -1,26 +1,35 @@
 const isEqual = require('lodash.isequal');
+const isFunction = require('lodash.isfunction');
 const mergeWith = require('lodash.mergewith');
 const unionWith = require('lodash.unionwith');
 const differenceWith = require('lodash.differencewith');
+const joinArrays = require('./join-arrays');
 
 const isArray = Array.isArray;
 
-module.exports = function uniteRules(newRule, rule, prepend) {
+function uniteRules(newRule, rule, strategy) {
   if (String(rule.test) !== String(newRule.test)
       || (newRule.enforce && rule.enforce !== newRule.enforce)
       || (newRule.include && !isSameValue(rule.include, newRule.include))
       || (newRule.exclude && !isSameValue(rule.exclude, newRule.exclude))) {
     return false;
+  } else if (!rule.test && !rule.include && !rule.exclude
+      && (rule.loader && rule.loader.split('?')[0]) !== (newRule.loader && newRule.loader.split('?')[0])) {
+    // Don't merge the rule if there isn't any identifying fields and the loaders don't match
+    return false;
   }
 
   // webpack 2 nested rules support
   if (rule.rules) {
-    rule.rules = prepend
-        ? [
-          ...differenceWith(newRule.rules, rule.rules, (b, a) => uniteRules(b, a, true)),
-          ...rule.rules
-        ]
-        : unionWith(rule.rules, newRule.rules, uniteRules);
+    const _uniteRules = (b, a) => uniteRules(b, a, strategy);
+    switch (strategy) {
+      case 'prepend':
+        rule.rules = [...differenceWith(newRule.rules, rule.rules, _uniteRules), ...rule.rules];
+        break;
+      default:
+        rule.rules = unionWith(rule.rules, newRule.rules, uniteRules);
+        break;
+    }
   }
 
   // newRule.loader should always override
@@ -63,9 +72,17 @@ module.exports = function uniteRules(newRule, rule, prepend) {
     const newEntries = [].concat(newRule.use || newRule.loaders).map(expandEntry);
 
     const loadersKey = rule.use || newRule.use ? 'use' : 'loaders';
-    rule[loadersKey] = prepend
-        ? [...differenceWith(newEntries, entries, uniteEntries), ...entries].map(unwrapEntry)
-        : unionWith(entries, newEntries, uniteEntries).map(unwrapEntry);
+    switch (strategy) {
+      case 'prepend':
+        rule[loadersKey] = [
+          ...differenceWith(newEntries, entries, uniteEntries),
+          ...entries
+        ].map(unwrapEntry);
+        break;
+      default:
+        rule[loadersKey] = unionWith(entries, newEntries, uniteEntries).map(unwrapEntry);
+        break;
+    }
   }
 
   if (newRule.include) {
@@ -77,7 +94,7 @@ module.exports = function uniteRules(newRule, rule, prepend) {
   }
 
   return true;
-};
+}
 
 /**
  * Check equality of two values using lodash's isEqual
@@ -106,3 +123,15 @@ function uniteEntries(newEntry, entry) {
   mergeWith(entry, newEntry);
   return true;
 }
+
+function unitePlugins(newPlugin, plugin) {
+  if (!(newPlugin instanceof plugin.constructor)) return false;
+
+  // functions shouldn't be merged here
+  mergeWith(plugin, newPlugin, (a, b, k) => (isFunction(a) ? a : joinArrays()(a, b, k)));
+  return true;
+}
+
+exports.uniteRules = uniteRules;
+exports.uniteEntries = uniteEntries;
+exports.unitePlugins = unitePlugins;

--- a/src/join-arrays.js
+++ b/src/join-arrays.js
@@ -1,41 +1,66 @@
-const cloneDeep = require('lodash.clonedeep');
+const cloneDeepWith = require('lodash.clonedeepwith');
+const isBoolean = require('lodash.isboolean');
 const isFunction = require('lodash.isfunction');
+const isObject = require('lodash.isobject');
+const isNumber = require('lodash.isnumber');
 const isPlainObject = require('lodash.isplainobject');
+const isString = require('lodash.isstring');
 const mergeWith = require('lodash.mergewith');
 
 const isArray = Array.isArray;
 
-module.exports = function joinArrays({
-  customizeArray,
-  customizeObject,
-  key
-} = {}) {
+module.exports = function joinArrays({ customizeArray, customizeObject, key } = {}) {
   return function _joinArrays(a, b, k) {
     const newKey = key ? `${key}.${k}` : k;
 
     if (isFunction(a) && isFunction(b)) {
       return (...args) => _joinArrays(a(...args), b(...args), k);
     }
+
     if (isArray(a) && isArray(b)) {
       const customResult = customizeArray && customizeArray(a, b, newKey);
 
-      return customResult || [...a, ...b];
+      return customResult || [...a, ...cloneDeepWith(b, clonePrototype)];
     }
 
-    if (isPlainObject(a) && isPlainObject(b)) {
-      const customResult = customizeObject && customizeObject(a, b, newKey);
-
-      return customResult || mergeWith({}, a, b, joinArrays({
-        customizeArray,
-        customizeObject,
-        key: newKey
-      }));
-    }
-
-    if (isPlainObject(b)) {
-      return cloneDeep(b);
+    if (isObject(b)) {
+      if (a instanceof b.constructor) {
+        if (isPlainObject(b)) {
+          const customResult = customizeObject && customizeObject(a, b, newKey);
+          return customResult || mergeWith(a, b, joinArrays({
+            customizeArray,
+            customizeObject,
+            key: newKey
+          }));
+        }
+        Object.getOwnPropertyNames(b).forEach((prop) => {
+          const customResult = customizeObject && customizeObject(a[prop], b[prop], `${newKey}.${prop}`);
+          a[prop] = customResult || mergeWith(a[prop], b[prop], joinArrays({
+            customizeArray,
+            customizeObject,
+            key: `${newKey}.${prop}`
+          }));
+        });
+        return a;
+      }
+      return cloneDeepWith(b, clonePrototype);
     }
 
     return b;
   };
 };
+
+function clonePrototype(o) {
+  if (!isObject(o) || isArray(o) || isBoolean(o) || isNumber(o) || isPlainObject(o) || isString(o)
+      || o instanceof RegExp) {
+    return;
+  }
+  if (isFunction(o)) {
+    return o;
+  }
+  const clone = Object.create(Object.getPrototypeOf(o));
+  Object.getOwnPropertyNames(o).forEach((prop) => {
+    clone[prop] = cloneDeepWith(o[prop], clonePrototype);
+  });
+  return clone;
+}

--- a/tests/merge-smart-tests.js
+++ b/tests/merge-smart-tests.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 const assert = require('assert');
 const loadersKeys = require('./loaders-keys');
+const webpack = require('webpack');
 
 function mergeSmartTests(merge) {
   commonTests(merge);
@@ -603,6 +604,86 @@ function mergeSmartTest(merge, loadersKey) {
     ];
 
     assert.deepEqual(merge(common, eslint), result);
+  });
+
+  it('should not merge rules that only have a loader definition', function () {
+    // these shouldn't be merged because none of `test`, `include`, nor `exclude` are defined.
+    // This is useful when using Webpack 2 nested rules
+    const common = {
+      module: {}
+    };
+    common.module[loadersKey] = [
+      {
+        test: /\.jsx?$/,
+        rules: [{ loader: 'eslint' }]
+      }
+    ];
+    const isparta = {
+      module: {}
+    };
+    isparta.module[loadersKey] = [
+      {
+        test: /\.jsx?$/,
+        rules: [{ loader: 'isparta-instrumenter' }]
+      }
+    ];
+    const result = {
+      module: {}
+    };
+    result.module[loadersKey] = [
+      {
+        test: /\.jsx?$/,
+        rules: [
+          { loader: 'eslint' },
+          { loader: 'isparta-instrumenter' }
+        ]
+      }
+    ];
+
+    assert.deepEqual(merge(common, isparta), result);
+  });
+
+  it('should support merging plugins', function () {
+    const a = {
+      plugins: [
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            babel: {
+              sourceMaps: true,
+              presets: ['es2015']
+            }
+          }
+        })
+      ]
+    };
+    const b = {
+      plugins: [
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            babel: {
+              presets: ['es2016', 'stage-0']
+            }
+          }
+        })
+      ]
+    };
+    const result = {
+      plugins: [
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            babel: {
+              sourceMaps: true,
+              presets: ['es2015', 'es2016', 'stage-0']
+            }
+          }
+        })
+      ]
+    };
+    // The merged test function can't be compared
+    delete a.plugins[0].options.test;
+    delete b.plugins[0].options.test;
+    delete result.plugins[0].options.test;
+    assert.deepEqual(merge(a, b), result);
   });
 }
 


### PR DESCRIPTION
This is very basic but is suiting my needs so far. I haven't had time to add tests.

Basically the most helpful aspect of this is for merging `LoaderOptionsPlugin` entries.
```javascript
plugins: [
    new LoaderOptionsPlugin({
      options: {
        babel: { sourceRoot: '' },
        postcss: [
          require('postcss-cssnext')()
        ],
      }
    })
]
```
with
```javascript
plugins: [
    new LoaderOptionsPlugin({
      options: {
        postcss: [
          require('postcss-url')({ url: url => url.replace('../server/assets', 'http://localhost:3000/assets') })
        ]
      }
    })
]
```
yields a plugin entry with both `postcss` plugins added. Currently functions aren't merged since merging the `apply` function from the two entries causes webpack to error.