### PR TITLE
Cannot prepend loader with merge.smart

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,32 @@ merge.smart({
 }
 ```
 
-**Loader query strings `loaders: ['babel?plugins[]=object-assign']` will be overridden**
+**Loader array values `loaders: ['babel']` can be reordered by including
+original loaders.**
+
+```javascript
+merge.smart({
+  loaders: [{
+    test: /\.js$/,
+    loaders: ['babel']
+  }]
+}, {
+  loaders: [{
+    test: /\.js$/,
+    loaders: ['react-hot', 'babel']
+  }]
+});
+// will become
+{
+  loaders: [{
+    test: /\.js$/,
+    // order of second argument is respected
+    loaders: ['react-hot', 'babel']
+  }]
+}
+```
+
+**Loader query strings `loaders: ['babel?plugins[]=object-assign']` will be overridden.**
 
 ```javascript
 merge.smart({

--- a/src/join-arrays-smart.js
+++ b/src/join-arrays-smart.js
@@ -72,7 +72,13 @@ function uniteRules(rules, key, newRule, rule) {
         rule[loadersKey] = newRule.use || newRule.loaders;
         break;
       default:
-        rule[loadersKey] = unionWith(entries, newEntries, uniteEntries).map(unwrapEntry);
+        rule[loadersKey] = unionWith(
+          // Remove existing entries so that we can respect the order of the new
+          // entries
+          differenceWith(entries, newEntries, isEqual),
+          newEntries,
+          uniteEntries
+        ).map(unwrapEntry);
     }
   }
 

--- a/tests/merge-smart-tests.js
+++ b/tests/merge-smart-tests.js
@@ -800,6 +800,49 @@ function mergeSmartTest(merge, loadersKey) {
 
     assert.deepEqual(merge(common, eslint), result);
   });
+
+  it('should respect a new order for ' + loadersKey, function () {
+    const common = {
+      module: {}
+    };
+    common.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          'css-loader'
+        ]
+      }
+    ];
+    const extractText = {
+      module: {}
+    };
+    extractText.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          'extract-text',
+          'style-loader',
+          'css-loader'
+        ]
+      }
+    ];
+    const result = {
+      module: {}
+    };
+    result.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          'extract-text',
+          'style-loader',
+          'css-loader'
+        ]
+      }
+    ];
+
+    assert.deepEqual(merge(common, extractText), result);
+  });
 }
 
 module.exports = mergeSmartTests;


### PR DESCRIPTION
Just for clarification, by prepend I mean prepend to the list of loaders (I know that this will run it last, that is what I want)

I'm trying to prepend a loader with merge.smart. I can't seem to get it to prepend, it always appends to the list. Here's a failing test.

Normally I'd find another way to do it, but `webpack-blocks` makes use of `merge.smart`, so it'd be great if it could work in this way. Thanks!

