### PR TITLE
fix: smart merge should maintain existing loader order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.1.3 / 2018-06-04
+==================
+
+  * Fix - Smart merge respects the existing loader order #79
+
 4.1.1 / 2017-11-01
 ==================
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,69 @@ merge.smart({
 }
 ```
 
+This also works in reverse - the existing order will be maintained if possible:
+
+```javascript
+merge.smart({
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'css-loader', options: { myOptions: true } },
+      { loader: 'style-loader' }
+    ]
+  }]
+}, {
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'style-loader', options: { someSetting: true } }
+    ]
+  }]
+});
+// will become
+{
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'css-loader', options: { myOptions: true } },
+      { loader: 'style-loader', options: { someSetting: true } }
+    ]
+  }]
+}
+```
+
+In the case of an order conflict, the second order wins:
+```javascript
+merge.smart({
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'css-loader' },
+      { loader: 'style-loader' }
+    ]
+  }]
+}, {
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'style-loader' },
+      { loader: 'css-loader' }
+    ]
+  }]
+});
+// will become
+{
+  loaders: [{
+    test: /\.css$/,
+    use: [
+      { loader: 'style-loader' }
+      { loader: 'css-loader' },
+    ]
+  }]
+}
+```
+
+
 **Loader query strings `loaders: ['babel?plugins[]=object-assign']` will be overridden.**
 
 ```javascript

--- a/tests/merge-smart-tests.js
+++ b/tests/merge-smart-tests.js
@@ -843,6 +843,90 @@ function mergeSmartTest(merge, loadersKey) {
 
     assert.deepEqual(merge(common, extractText), result);
   });
+
+  it('should respect the existing order for ' + loadersKey, function () {
+    const common = {
+      module: {}
+    };
+    common.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'css-loader', options: { myOptions: true } },
+          { loader: 'style-loader' }
+        ]
+      }
+    ];
+    const extractText = {
+      module: {}
+    };
+    extractText.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader', options: { someSetting: true } }
+        ]
+      }
+    ];
+    const result = {
+      module: {}
+    };
+    result.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'css-loader', options: { myOptions: true } },
+          { loader: 'style-loader', options: { someSetting: true } }
+        ]
+      }
+    ];
+
+    assert.deepEqual(merge(common, extractText), result);
+  });
+
+  it('should respect second order when existing/new have conflicting orders for ' + loadersKey, function () {
+    const common = {
+      module: {}
+    };
+    common.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'css-loader' },
+          { loader: 'style-loader' },
+          { loader: 'other-loader' }
+        ]
+      }
+    ];
+
+    const extractText = {
+      module: {}
+    };
+    extractText.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader' },
+          { loader: 'css-loader' }
+        ]
+      }
+    ];
+    const result = {
+      module: {}
+    };
+    result.module[loadersKey] = [
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          'css-loader',
+          'other-loader'
+        ]
+      }
+    ];
+
+    assert.deepEqual(merge(common, extractText), result);
+  });
 }
 
 module.exports = mergeSmartTests;


### PR DESCRIPTION
In a situation where loader order is specified in a
previous config, one of those loaders being referenced in
a subsequent config shouldn't ignore the previous order.

Fixes #79