### PR TITLE
docs: update  example code of Limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ const productionConfig = { ... };
 
 const developmentConfig = { ... };
 
-module.exports = env => {
-  switch(env) {
+module.exports = (env, args) => {
+  switch(args.mode) {
     case 'development':
       return merge(commonConfig, developmentConfig);
     case 'production':
@@ -56,7 +56,7 @@ module.exports = env => {
 }
 ```
 
-You can choose the configuration you want by using `webpack --env development` assuming you are using _webpack-cli_.
+You can choose the configuration you want by using `webpack --mode development` assuming you are using _webpack-cli_.
 
 ## **`mergeWithCustomize({ customizeArray, customizeObject })(...configuration | [...configuration])`**
 


### PR DESCRIPTION
just adjust example code by webpack [doc](https://webpack.js.org/configuration/mode/#mode-none)

for previous code
if you use `webpack --env development` command in webpack 5.3,
then `env` will be
`{ WEBPACK_SERVE: true, development: true }`,  instead of `development` or `production `
